### PR TITLE
Add word boundary to zen.coffee

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,1 +1,1 @@
-["redis-brain.coffee", "shipit.coffee", "ruby.coffee", "github-status.coffee", "insult.coffee", "javascript-sandbox.coffee", "zen.coffee"]
+["redis-brain.coffee", "shipit.coffee", "ruby.coffee", "github-status.coffee", "insult.coffee", "javascript-sandbox.coffee"]

--- a/scripts/zen.coffee
+++ b/scripts/zen.coffee
@@ -1,0 +1,22 @@
+# Description:
+#   Display GitHub zen message from https://api.github.com/zen API
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   zen - Display GitHub zen message
+#
+# Author:
+#   anildigital
+#
+
+module.exports = (robot) ->
+  robot.hear /\b(zen)\b/i, (msg) ->
+    msg
+      .http("https://api.github.com/zen")
+      .get() (err, res, body) ->
+        msg.send body


### PR DESCRIPTION
This replaces the `zen.coffee` script from `github/hubot-scripts` with a modified version with a less shitty regular expression. I also submitted this as a PR to `github/hubot-scripts`, so if it ever gets merged, we can go back to using that version.
